### PR TITLE
Extensions element validation

### DIFF
--- a/specs-compliance-tests/xsd/saml-schema-metadata-sp-spid-av29.xsd
+++ b/specs-compliance-tests/xsd/saml-schema-metadata-sp-spid-av29.xsd
@@ -56,8 +56,9 @@
         </simpleContent>
     </complexType>
     
-    <element name="Extensions" type="md:ContactPersonExtensionType"/>
-
+    <element name="Extensions" type="md:ExtensionsType"/>
+    <element name="ContactPersonExtension" type="md:ContactPersonExtensionType"/>
+    
     <complexType final="#all" name="ExtensionsType">
         <sequence>
             <any namespace="##other" processContents="lax" maxOccurs="unbounded"/>


### PR DESCRIPTION
With this PR we can validate the ContactPersonExtension spid extension and at the same time all the SAML2 defaults extensions element, like, for example, `idpdisc:DiscoveryResponse` that, at this moment, fails with the following error:

````
[FAIL] the metadata must validate against the XSD
stderr: data/https___172_17_0_1_10000_spidSaml2_metadata/sp-metadata.xml:9: element DiscoveryResponse: 
        Schemas validity error : Element '{urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol}DiscoveryResponse': 
        This element is not expected. Expected is one of 
        ( {https://spid.gov.it/saml-extensions}IPACode, {https://spid.gov.it/saml-extensions}VATNumber, 
          {https://spid.gov.it/saml-extensions}FiscalCode, 
          {https://spid.gov.it/saml-extensions}Public, 
          {https://spid.gov.it/saml-extensions}Private, 
          {https://spid.gov.it/invoicing-extensions}CessionarioCommittente ).
stderr: data/https___172_17_0_1_10000_spidSaml2_metadata/sp-metadata.xml fails to validate
````

It would fixes this issue: 
https://github.com/italia/spid-saml-check/issues/98