### PR TITLE
Docker enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,6 @@
 FROM debian:buster
 LABEL mantainer="Michele D'Amico, michele.damico@agid.gov.it"
 
-# Set the working directory
-WORKDIR /spid-saml-check
-
-# Copy the current directory to /spid-validator
-ADD . /spid-saml-check
-
-# Create directory for tests data
-RUN mkdir /spid-saml-check/specs-compliance-tests/data
-
-ENV \
-    DATA_DIR=/spid-saml-check/specs-compliance-tests/data \
-    SP_METADATA=/spid-saml-check/specs-compliance-tests/data/sp-metadata.xml \
-    AUTHN_REQUEST=/spid-saml-check/specs-compliance-tests/data/authn-request.xml
-
 # Update and install utilities
 RUN apt-get update \
     && apt-get install -y \
@@ -37,6 +23,15 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
 
 # Tox
 RUN pip3 install tox
+
+# Set the working directory
+WORKDIR /spid-saml-check
+
+# Copy the current directory to /spid-validator
+ADD . /spid-saml-check
+
+# Create directory for tests data
+RUN mkdir /spid-saml-check/specs-compliance-tests/data
 
 # Build validator
 RUN cd /spid-saml-check/spid-validator && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ ADD . /spid-saml-check
 # Create directory for tests data
 RUN mkdir /spid-saml-check/specs-compliance-tests/data
 
+ENV \
+    TZ=Europe/Rome \
+    DATA_DIR=/spid-saml-check/specs-compliance-tests/data \
+    SP_METADATA=/spid-saml-check/specs-compliance-tests/data/sp-metadata.xml \
+    AUTHN_REQUEST=/spid-saml-check/specs-compliance-tests/data/authn-request.xml
+
 # Build validator
 RUN cd /spid-saml-check/spid-validator && \
     cd client && npm install --silent && cd .. && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  spid-saml-check:
+    build: .
+    container_name: spid-saml-check
+    restart: unless-stopped
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
The way the Dockerfile was written meant that docker layers caching was not leveraged as it should. With this PR the build time will be slimmed down to -50% or less when re-building, since all the initial plumbing will be cached and reused.