### PR TITLE
disable utc timezone transformation

### DIFF
--- a/spid-validator/server/lib/utils.js
+++ b/spid-validator/server/lib/utils.js
@@ -36,19 +36,19 @@ class Utils {
     }
 
     static getInstant() {
-        return moment().utc().format();
+        return moment().format();
     }
 
     static getInstantMillis() {
-        return moment().utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
+        return moment().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
     }
 
     static getNotBefore(instant) {
-        return moment(instant).utc().format();
+        return moment(instant).format();
     }
 
     static getNotOnOrAfter(instant) {
-        return moment(instant).add(5, 'm').utc().format();
+        return moment(instant).add(5, 'm').format();
     }
 
     static metadataDownload(src, dest) {


### PR DESCRIPTION
Any reason why in `utils.js` times are transformed to UTC in place of using the local time? This leads to issues with the `NotBefore` and `NotOnOrAfter` being wrongly issued by the tool 1hr before CET (Italy) timezone, therefore leading to SSO declining to handle such SAML assertions.