### PR TITLE
Allow to bootstrap SP metadata XML files

### DIFF
--- a/spid-validator/config/dir.json
+++ b/spid-validator/config/dir.json
@@ -1,4 +1,5 @@
 {
     "DATA": "../data",
-    "TEMP": "temp"
+    "TEMP": "temp",
+    "BOOTSTRAP": "bootstrap"
 }

--- a/spid-validator/server/lib/utils.js
+++ b/spid-validator/server/lib/utils.js
@@ -7,6 +7,7 @@ const moment = require("moment");
 const CryptoJS = require("crypto-js");
 const config_dir = require("../../config/dir.json");
 const config_idp = require("../../config/idp.json");
+const fs = require("fs-extra");
 
 
 String.prototype.replaceAll = function(search, replacement) {
@@ -126,6 +127,21 @@ class Utils {
     static atob(buffer) {
         return Buffer.from(buffer, 'base64').toString('ascii');
     }
-}
     
+  static readFiles(dirname, onFileContent, onError) {
+    fs.readdir(dirname, function (err, filenames) {
+      if (err) {
+        onError(err);
+        return;
+      }
+      filenames.forEach(function (filename) {
+        if (filename.indexOf('.xml') > 0) {
+          let content = fs.readFileSync(dirname + "/" + filename, "utf8");
+          onFileContent(filename, content);
+        }
+      });
+    });
+  }
+}
+
 module.exports = Utils;

--- a/spid-validator/server/spid-validator.js
+++ b/spid-validator/server/spid-validator.js
@@ -253,6 +253,22 @@ require('./api/response')    	(app, checkAuth);
 // start
 if (useHttps) app = https.createServer(httpsCredentials, app);
 app.listen(config_server.port, () => {
+  // import
+  if (fs.existsSync("../" + config_dir.DATA + "/" + config_dir.BOOTSTRAP)) {
+    Utility.readFiles("../" + config_dir.DATA + "/" + config_dir.BOOTSTRAP, function (filename, xml) {
+      let metadataParser = new MetadataParser(xml);
+
+      let entityID = metadataParser.getServiceProviderEntityId();
+      if (entityID === null || entityID === '')
+        throw new Error("EntityID non specificato");
+
+      fs.copyFileSync("../" + config_dir.DATA + "/" + config_dir.BOOTSTRAP + "/" + filename, getEntityDir(entityID) + "/sp-metadata.xml");
+      database.setMetadata("validator", "000", entityID, "000", "main", entityID, xml);
+    }, function (err) {
+      console.error("Could not bootstrap initial SP metadata: ", err);
+    });
+  }
+
     // eslint-disable-next-line no-console
     console.log("\n" + p.name + "\nversion: " + p.version + "\n\nlistening on port " + config_server.port);
 });


### PR DESCRIPTION
This PR features changes to allow for SP metadata bootstrap, thus enabling for easier usage in automated integration tests scenarios.

In order to enable such feature, it is enough to mount a volume in Docker with target `/data/bootstrap`: every XML file found there will be selected for import as SP metadata.