### PR TITLE
fix: missing double quotes around input values

### DIFF
--- a/spid-validator/client/view/demo_loading.handlebars
+++ b/spid-validator/client/view/demo_loading.handlebars
@@ -46,11 +46,11 @@
                         </div>
                     </div>
                     <form name="form" action="{{demo_basepath}}/start" method="post">
-                        <input type="hidden" name="samlRequest" value={{ samlRequest }} ></input>                                                  
-                        <input type="hidden" name="relayState" value={{ relayState }} ></input>                                                  
-                        <input type="hidden" name="sigAlg" value={{ sigAlg }} ></input>                                                  
-                        <input type="hidden" name="signature" value={{ signature }} ></input>   
-                        <input type="hidden" name="binding" value={{ binding }} ></input>                                                
+                        <input type="hidden" name="samlRequest" value="{{ samlRequest }}" ></input>                                                  
+                        <input type="hidden" name="relayState" value="{{ relayState }}" ></input>                                                  
+                        <input type="hidden" name="sigAlg" value="{{ sigAlg }}" ></input>                                                  
+                        <input type="hidden" name="signature" value="{{ signature }}" ></input>   
+                        <input type="hidden" name="binding" value="{{ binding }}" ></input>                                                
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
Form input fields are missing double quotes around values.
This may cause the validator to fail when the original SAML Base64 request contains spaces, as only the first fragment (up to the first space) would be considered.