### PR TITLE
fix: url validation using built-in class

### DIFF
--- a/spid-validator/server/lib/utils.js
+++ b/spid-validator/server/lib/utils.js
@@ -227,16 +227,12 @@ class Utils {
   }
 
   static isValidUrl(str) {
-    const pattern = new RegExp(
-      '^([a-zA-Z]+:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR IP (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$', // fragment locator
-      'i'
-    );
-    return pattern.test(str);
+      try {
+          new URL(str);
+          return true;
+      } catch (err) {
+          return false;
+      }
   }
 
 }


### PR DESCRIPTION
Uso la classe URL invece del RegExp, che è errato per alcune URL (tipo dentro docker `http://web:4000/metadata`, l'host non deve per forza avere il dominio).