### PR TITLE
feat: add custom User-Agent header to HTTP requests

### DIFF
--- a/spid-validator/client/src/services.js
+++ b/spid-validator/client/src/services.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import Utility from "./utility";
 
+axios.defaults.headers.common['User-Agent'] = 'spid-saml-check-client/1.0';
 
 class MainService {
 


### PR DESCRIPTION
This commit adds a custom `User-Agent` header to all outgoing HTTP requests made via Axios, enabling better identification of the spid-saml-check client when interacting with external services or APIs. This change helps improve traceability and diagnostics on the server side.

Note: If executed in a browser environment, the `User-Agent` header may be ignored due to browser restrictions. In such cases, a custom header (e.g., `X-Client-Identifier`) may be considered instead.