### PR TITLE
Check if URL exists now send a userAgent

### DIFF
--- a/spid-validator/server/lib/utils.js
+++ b/spid-validator/server/lib/utils.js
@@ -62,9 +62,21 @@ class Utils {
             if(!this.isValidUrl(src)) {
                 return reject("Inserire una URL valida");
             }
+            
+            const urlObj = new URL(src);
+
+            const options = {
+                hostname: urlObj.hostname,
+                port: urlObj.port || 8443,
+                path: urlObj.pathname + urlObj.search,
+                method: 'GET',
+                headers: {
+                    'User-Agent': 'spid-saml-check-client/1.0'
+                }
+            };
 
             // check if URL exists
-            https.get(src, (res) => {
+            https.get(options, (res) => {
                 if(res.statusCode!='200') {
                     return reject("Metadata non trovato alla URL indicata");
                 }


### PR DESCRIPTION
- Added a preliminary `https.get` request to verify that the metadata endpoint responds with `200 OK` before attempting the actual download.
- The request includes a custom `User-Agent` required by the server-side authorization gate ("semaphore").
- If the response is valid, the metadata is downloaded using `wget`.